### PR TITLE
Remove auxiliary variables with same/similar names as regular variables and same values

### DIFF
--- a/OneCellTwoOsc.ode
+++ b/OneCellTwoOsc.ode
@@ -37,11 +37,6 @@ h'= (hinf-h)/tauh
 C' = fi*( J_ER_in- J_ER_out)
 l' = A*( Kd - (C + Kd)*l )
 
-# Auxilary variables
-aux Ce=Ce
-aux ican=I_can
-aux inaps=I_nap
-
 #Initial conditions
 
 v(0)=-50


### PR DESCRIPTION
XPP raises warning
```
CE is a duplicate name
```